### PR TITLE
Add commands for annepro2_shine profiles

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -52,6 +52,32 @@ void annepro2LedEnable(void)
     sdPut(&SD0, CMD_LED_ON);
 }
 
+void annepro2LedSetProfile(void)
+{
+    sdPut(&SD0, CMD_LED_SET_PROFILE);
+}
+
+void annepro2LedNextProfile(void)
+{
+    sdPut(&SD0, CMD_LED_NEXT_PROFILE);
+}
+
+
+void annepro2LedPrevProfile(void)
+{
+    sdPut(&SD0, CMD_LED_PREV_PROFILE);
+}
+
+void annepro2LedGet(void)
+{
+    sdPut(&SD0, CMD_LED_GET_PROFILE);
+}
+
+void annepro2LedGetNum(void)
+{
+    sdPut(&SD0, CMD_LED_PREV_PROFILE);
+}
+
 void annepro2LedUpdate(uint8_t row, uint8_t col)
 {
     sdPut(&SD0, CMD_LED_SET);

--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -52,16 +52,10 @@ void annepro2LedEnable(void)
     sdPut(&SD0, CMD_LED_ON);
 }
 
-void annepro2LedSetProfile(void)
-{
-    sdPut(&SD0, CMD_LED_SET_PROFILE);
-}
-
 void annepro2LedNextProfile(void)
 {
     sdPut(&SD0, CMD_LED_NEXT_PROFILE);
 }
-
 
 void annepro2LedPrevProfile(void)
 {

--- a/keyboards/annepro2/annepro2.h
+++ b/keyboards/annepro2/annepro2.h
@@ -35,5 +35,10 @@ enum AP2KeyCodes {
 
 void annepro2LedDisable(void);
 void annepro2LedEnable(void);
+void annepro2LedSetProfile(void);
+void annepro2LedNextProfile(void);
+void annepro2LedPrevProfile(void);
+void annepro2LedGet(void);
+void annepro2LedGetNum(void);
 void annepro2LedUpdate(uint8_t row, uint8_t col);
 void annepro2LedUpdateRow(uint8_t row);

--- a/keyboards/annepro2/annepro2.h
+++ b/keyboards/annepro2/annepro2.h
@@ -35,7 +35,6 @@ enum AP2KeyCodes {
 
 void annepro2LedDisable(void);
 void annepro2LedEnable(void);
-void annepro2LedSetProfile(void);
 void annepro2LedNextProfile(void);
 void annepro2LedPrevProfile(void);
 void annepro2LedGet(void);

--- a/keyboards/annepro2/keymaps/default/keymap.c
+++ b/keyboards/annepro2/keymaps/default/keymap.c
@@ -9,6 +9,12 @@ enum anne_pro_layers {
 enum custom_keys {
     KC_AP_LED_ON = AP2_SAFE_RANGE,
     KC_AP_LED_OFF,
+    KC_AP_LED_SET,
+    KC_AP_LED_SET_PROFILE,
+    KC_AP_LED_NEXT_PROFILE,
+    KC_AP_LED_PREV_PROFILE,
+    KC_AP_LED_GET_PROFILE,
+    KC_AP_LED_GET_NUM_PROFILES
 };
 /*
 * Layer _BASE_LAYER
@@ -113,9 +119,19 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 annepro2LedDisable();
             return false;
         case KC_AP_LED_ON:
-            if (record->event.pressed)
+            if (record->event.pressed) {
                 annepro2LedEnable();
-            return false;
+	    	annepro2LedNextProfile();
+	    }
+	    return false;
+	case KC_AP_LED_NEXT_PROFILE:
+	    if (record->event.pressed) 
+	        annepro2LedNextProfile();
+	    return false;
+	case KC_AP_LED_PREV_PROFILE:
+	    if (record->event.pressed)
+	        annepro2LedPrevProfile();
+	    return false;
         default:
             break;
     }

--- a/keyboards/annepro2/qmk_ap2_led.h
+++ b/keyboards/annepro2/qmk_ap2_led.h
@@ -4,3 +4,8 @@
 #define CMD_LED_OFF                         0x2
 #define CMD_LED_SET                         0x3
 #define CMD_LED_SET_ROW                     0x4
+#define CMD_LED_SET_PROFILE                 0x5
+#define CMD_LED_NEXT_PROFILE                0x6
+#define CMD_LED_PREV_PROFILE                0x7
+#define CMD_LED_GET_PROFILE                 0x8
+#define CMD_LED_GET_NUM_PROFILES            0x9


### PR DESCRIPTION
https://github.com/OpenAnnePro/AnnePro2-Shine/commit/9202d03de52b3e2ffcc7197b99be6e10b0e39011
The commit above added commands in annepro2_shine that allows for switching led profiles.

I added commands for the qmk firmware to work with the new commands. 

This is my first pull request, please correct me if I'm doing something wrong.

I'm gonna add the bidirectional communication later because I'm not good at it yet.