### PR TITLE
Keyboard annepro2 bidir led comms

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -2,7 +2,6 @@
 #include "hal.h"
 #include "annepro2.h"
 #include "annepro2_ble.h"
-#include "qmk_ap2_led.h"
 
 static const SerialConfig ledUartConfig = {
   .speed = 115200,
@@ -26,6 +25,9 @@ uint16_t annepro2LedMatrix[MATRIX_ROWS * MATRIX_COLS] = {
 };
 
 void OVERRIDE keyboard_pre_init_kb(void) {
+#if HAL_USE_SPI == TRUE
+    spi_init();
+#endif
 }
 
 void OVERRIDE keyboard_post_init_kb(void) {
@@ -33,44 +35,17 @@ void OVERRIDE keyboard_post_init_kb(void) {
     sdStart(&SD0, &ledUartConfig);
     sdWrite(&SD0, ledMcuWakeup, 11);
 
+    wait_ms(75);
+
     // Start BLE UART
     sdStart(&SD1, &bleUartConfig);
     annepro2_ble_startup();
+
+    keyboard_post_init_user();
 }
 
 void OVERRIDE matrix_init_kb(void) {
     matrix_init_user();
-}
-
-void annepro2LedDisable(void)
-{
-    sdPut(&SD0, CMD_LED_OFF);
-}
-
-void annepro2LedEnable(void)
-{
-    sdPut(&SD0, CMD_LED_ON);
-}
-
-void annepro2LedUpdate(uint8_t row, uint8_t col)
-{
-    sdPut(&SD0, CMD_LED_SET);
-    sdPut(&SD0, row);
-    sdPut(&SD0, col);
-    sdWrite(&SD0, (uint8_t *)&annepro2LedMatrix[row * MATRIX_COLS + col], sizeof(uint16_t));
-}
-
-void annepro2LedUpdateRow(uint8_t row)
-{
-    sdPut(&SD0, CMD_LED_SET_ROW);
-    sdPut(&SD0, row);
-    sdWrite(&SD0, (uint8_t *)&annepro2LedMatrix[row * MATRIX_COLS], sizeof(uint16_t) * MATRIX_COLS);
-}
-
-bool OVERRIDE led_update_kb(led_t status) {
-    annepro2LedMatrix[2 * MATRIX_COLS] = status.caps_lock ? 0x4FF : 0;
-    annepro2LedUpdate(2, 0);
-    return led_update_user(status);
 }
 
 /*!

--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -25,17 +25,12 @@ uint16_t annepro2LedMatrix[MATRIX_ROWS * MATRIX_COLS] = {
 };
 
 void OVERRIDE keyboard_pre_init_kb(void) {
-#if HAL_USE_SPI == TRUE
-    spi_init();
-#endif
 }
 
 void OVERRIDE keyboard_post_init_kb(void) {
     // Start LED UART
     sdStart(&SD0, &ledUartConfig);
     sdWrite(&SD0, ledMcuWakeup, 11);
-
-    wait_ms(75);
 
     // Start BLE UART
     sdStart(&SD1, &bleUartConfig);

--- a/keyboards/annepro2/annepro2.h
+++ b/keyboards/annepro2/annepro2.h
@@ -32,8 +32,3 @@ enum AP2KeyCodes {
     KC_AP2_USB,
     AP2_SAFE_RANGE,
 };
-
-void annepro2LedDisable(void);
-void annepro2LedEnable(void);
-void annepro2LedUpdate(uint8_t row, uint8_t col);
-void annepro2LedUpdateRow(uint8_t row);

--- a/keyboards/annepro2/c15/rules.mk
+++ b/keyboards/annepro2/c15/rules.mk
@@ -2,7 +2,8 @@
 SRC = \
 	matrix.c \
 	hardfault_handler.c \
-	annepro2_ble.c
+	annepro2_ble.c \
+    qmk_ap2_led.c
 
 LAYOUTS +=
 

--- a/keyboards/annepro2/c18/rules.mk
+++ b/keyboards/annepro2/c18/rules.mk
@@ -2,7 +2,8 @@
 SRC = \
 	matrix.c \
 	hardfault_handler.c \
-	annepro2_ble.c
+	annepro2_ble.c \
+	qmk_ap2_led.c
 
 LAYOUTS +=
 

--- a/keyboards/annepro2/keymaps/codetector/keymap.c
+++ b/keyboards/annepro2/keymaps/codetector/keymap.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "annepro2.h"
+#include "qmk_ap2_led.h"
 
 enum anne_pro_layers {
   _BASE_LAYER,
@@ -64,14 +65,16 @@ layer_state_t layer_state_set_user(layer_state_t layer) {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case KC_AP_LED_OFF:
-            if (record->event.pressed)
+            if (record->event.pressed) {
                 annepro2LedDisable();
                 annepro2LedPrevProfile();
+            }
             return false;
         case KC_AP_LED_ON:
-            if (record->event.pressed)
+            if (record->event.pressed) {
                 annepro2LedEnable();
                 annepro2LedNextProfile();
+            }
             return false;
         default:
             break;

--- a/keyboards/annepro2/keymaps/codetector/keymap.c
+++ b/keyboards/annepro2/keymaps/codetector/keymap.c
@@ -66,10 +66,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case KC_AP_LED_OFF:
             if (record->event.pressed)
                 annepro2LedDisable();
+                annepro2LedPrevProfile();
             return false;
         case KC_AP_LED_ON:
             if (record->event.pressed)
                 annepro2LedEnable();
+                annepro2LedNextProfile();
             return false;
         default:
             break;

--- a/keyboards/annepro2/keymaps/default/keymap.c
+++ b/keyboards/annepro2/keymaps/default/keymap.c
@@ -111,10 +111,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case KC_AP_LED_OFF:
             if (record->event.pressed)
                 annepro2LedDisable();
+                annepro2LedPrevProfile();
             return false;
         case KC_AP_LED_ON:
             if (record->event.pressed)
                 annepro2LedEnable();
+                annepro2LedNextProfile();
             return false;
         default:
             break;

--- a/keyboards/annepro2/keymaps/default/keymap.c
+++ b/keyboards/annepro2/keymaps/default/keymap.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "annepro2.h"
+#include "qmk_ap2_led.h"
 
 enum anne_pro_layers {
   _BASE_LAYER,
@@ -109,14 +110,16 @@ layer_state_t layer_state_set_user(layer_state_t layer) {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case KC_AP_LED_OFF:
-            if (record->event.pressed)
+            if (record->event.pressed) {
                 annepro2LedDisable();
                 annepro2LedPrevProfile();
+            }
             return false;
         case KC_AP_LED_ON:
-            if (record->event.pressed)
+            if (record->event.pressed) {
                 annepro2LedEnable();
                 annepro2LedNextProfile();
+            }
             return false;
         default:
             break;

--- a/keyboards/annepro2/qmk_ap2_led.c
+++ b/keyboards/annepro2/qmk_ap2_led.c
@@ -1,0 +1,55 @@
+#include "hal.h"
+#include "annepro2.h"
+#include "qmk_ap2_led.h"
+
+void annepro2LedDisable(void)
+{
+  sdPut(&SD0, CMD_LED_OFF);
+}
+
+void annepro2LedEnable(void)
+{
+  sdPut(&SD0, CMD_LED_ON);
+}
+
+void annepro2LedUpdate(uint8_t row, uint8_t col)
+{
+  sdPut(&SD0, CMD_LED_SET);
+  sdPut(&SD0, row);
+  sdPut(&SD0, col);
+  sdWrite(&SD0, (uint8_t *)&annepro2LedMatrix[row * MATRIX_COLS + col], sizeof(uint16_t));
+}
+
+void annepro2LedUpdateRow(uint8_t row)
+{
+  sdPut(&SD0, CMD_LED_SET_ROW);
+  sdPut(&SD0, row);
+  sdWrite(&SD0, (uint8_t *)&annepro2LedMatrix[row * MATRIX_COLS], sizeof(uint16_t) * MATRIX_COLS);
+}
+
+void annepro2LedSetProfile(uint8_t prof)
+{
+  sdPut(&SD0, CMD_LED_SET_PROFILE);
+  sdPut(&SD0, prof);
+}
+
+uint8_t annepro2LedGetProfile()
+{
+  uint8_t buf = 0;
+  sdPut(&SD0, CMD_LED_GET_PROFILE);
+  buf = sdGet(&SD0);
+  return buf;
+}
+
+uint8_t annepro2LedGetNumProfiles()
+{
+  uint8_t buf = 0;
+  sdPut(&SD0, CMD_LED_GET_NUM_PROFILES);
+  buf = sdGet(&SD0);
+  return buf;
+}
+
+void annepro2LedNextProfile()
+{
+  sdPut(&SD0, CMD_LED_NEXT_PROFILE);
+}

--- a/keyboards/annepro2/qmk_ap2_led.c
+++ b/keyboards/annepro2/qmk_ap2_led.c
@@ -53,3 +53,8 @@ void annepro2LedNextProfile()
 {
   sdPut(&SD0, CMD_LED_NEXT_PROFILE);
 }
+
+void annepro2LedPrevProfile()
+{
+  sdPut(&SD0, CMD_LED_PREV_PROFILE);
+}

--- a/keyboards/annepro2/qmk_ap2_led.h
+++ b/keyboards/annepro2/qmk_ap2_led.h
@@ -4,3 +4,17 @@
 #define CMD_LED_OFF                         0x2
 #define CMD_LED_SET                         0x3
 #define CMD_LED_SET_ROW                     0x4
+#define CMD_LED_SET_PROFILE                 0x5
+#define CMD_LED_NEXT_PROFILE                0x6
+#define CMD_LED_PREV_PROFILE                0x7
+#define CMD_LED_GET_PROFILE                 0x8
+#define CMD_LED_GET_NUM_PROFILES            0x9
+
+void annepro2LedDisable(void);
+void annepro2LedEnable(void);
+void annepro2LedUpdate(uint8_t row, uint8_t col);
+void annepro2LedUpdateRow(uint8_t row);
+void annepro2LedSetProfile(uint8_t prof);
+uint8_t annepro2LedGetProfile(void);
+uint8_t annepro2LedGetNumProfiles(void);
+void annepro2LedNextProfile(void);

--- a/keyboards/annepro2/qmk_ap2_led.h
+++ b/keyboards/annepro2/qmk_ap2_led.h
@@ -18,3 +18,4 @@ void annepro2LedSetProfile(uint8_t prof);
 uint8_t annepro2LedGetProfile(void);
 uint8_t annepro2LedGetNumProfiles(void);
 void annepro2LedNextProfile(void);
+void annepro2LedPrevProfile(void);


### PR DESCRIPTION
Isolated PR for bidirectional shine comms from PR #3 

- Split led functions into their own file
- Preserve original functionality in existing keymaps
- Faster led startup time moving shine initialization into pre_init