### PR TITLE
Keyboard annepro2 ble caps lock

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -17,6 +17,7 @@ static uint8_t ledMcuWakeup[11] = {
     0x7b, 0x10, 0x43, 0x10, 0x03, 0x00, 0x00, 0x7d, 0x02, 0x01, 0x02
 };
 
+ble_capslock_t BLECapsLock = {._dummy = {0}, .caps_lock = false};
 
 uint16_t annepro2LedMatrix[MATRIX_ROWS * MATRIX_COLS] = {
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -50,7 +51,11 @@ void OVERRIDE keyboard_post_init_kb(void) {
 
     // Give the send uart thread some time to
     // send out the queue before we read back
-    wait_ms(5);
+    wait_ms(15);
+
+    // loop to clear out receive buffer from ble wakeup
+    while(!sdGetWouldBlock(&SD1))
+        sdGet(&SD1);
 
     keyboard_post_init_user();
 }
@@ -60,7 +65,23 @@ void OVERRIDE matrix_init_kb(void) {
 }
 
 void matrix_scan_kb() {
+    // if there's stuff on the ble serial buffer
+    // read it into the capslock struct
+    while(!sdGetWouldBlock(&SD1)) {
+        sdReadTimeout(&SD1, (uint8_t *) &BLECapsLock, sizeof(ble_capslock_t), 10);
+
+        // if it's capslock from ble, darken led
+        if (BLECapsLock.caps_lock) {
+            annepro2LedClearMask(MATRIX_COLS * 2);
+        } else {
+            annepro2LedSetMask(MATRIX_COLS * 2);
+        }
+    }
+
+
+    matrix_scan_user();
 }
+
 /*!
  * @returns false   processing for this keycode has been completed.
  */

--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -59,6 +59,8 @@ void OVERRIDE matrix_init_kb(void) {
     matrix_init_user();
 }
 
+void matrix_scan_kb() {
+}
 /*!
  * @returns false   processing for this keycode has been completed.
  */

--- a/keyboards/annepro2/annepro2.h
+++ b/keyboards/annepro2/annepro2.h
@@ -21,7 +21,14 @@
 
 #define OVERRIDE __attribute__ ((noinline))
 
+typedef struct __attribute__((__packed__)) {
+    uint8_t _dummy[10];
+    bool caps_lock;
+} ble_capslock_t;
+
 extern uint16_t annepro2LedMatrix[MATRIX_ROWS * MATRIX_COLS];
+
+extern ble_capslock_t BLECapsLock;
 
 enum AP2KeyCodes {
     KC_AP2_BT1 = SAFE_RANGE,

--- a/keyboards/annepro2/boards/ANNEPRO2/board.c
+++ b/keyboards/annepro2/boards/ANNEPRO2/board.c
@@ -176,10 +176,6 @@ void __early_init(void) {
     ht32_clock_init();
 }
 
-void matrix_scan_kb() {
-    matrix_scan_user();
-}
-
 /**
  * @brief   Board-specific initialization code.
  * @todo    Add your board-specific code, if any.


### PR DESCRIPTION
Added a conditional to the matrix scan to check for caplock message from ble mcu when connected over ble. Small change, can be extended in keymap via matrix_scan_user.