### PR TITLE
Merge the custom keys enums on annepro2.h

### DIFF
--- a/keyboards/annepro2/annepro2.h
+++ b/keyboards/annepro2/annepro2.h
@@ -30,12 +30,9 @@ enum AP2KeyCodes {
     KC_AP2_BT4,
     KC_AP2_BT_UNPAIR,
     KC_AP2_USB,
-    AP2_SAFE_RANGE,
-};
-
-enum custom_keys {
-    KC_AP_LED_ON = AP2_SAFE_RANGE,
+    KC_AP_LED_ON,
     KC_AP_LED_OFF,
     KC_AP_LED_NEXT_PROFILE,
-    KC_AP_LED_PREV_PROFILE
+    KC_AP_LED_PREV_PROFILE,
+    AP2_SAFE_RANGE,
 };


### PR DESCRIPTION
Merge the custom_keys enum on annepro2.h with the AP2KeyCodes, so that the AP2_SAFE_RANGE on the end of the enum can be treated as an actual safe range.

## Description

Currently the AP2_SAFE_RANGE is conflicting with the values on the custom_keys on annepro2.h and this forces people who want to make custom new keys to resort to workarounds such as using AP2_SAFE_RANGE + 10 (which kind of defeats the purpose of having a SAFE_RANGE after all).

This change is aimed at fixing this so the user can use AP2_SAFE_RANGE safely.

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
