### PR TITLE
Improve logic for switching off and on of LEDs

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -17,6 +17,8 @@ static uint8_t ledMcuWakeup[11] = {
     0x7b, 0x10, 0x43, 0x10, 0x03, 0x00, 0x00, 0x7d, 0x02, 0x01, 0x02
 };
 
+static bool ledEnabled = false;
+
 ble_capslock_t BLECapsLock = {._dummy = {0}, .caps_lock = false};
 
 uint16_t annepro2LedMatrix[MATRIX_ROWS * MATRIX_COLS] = {
@@ -113,13 +115,17 @@ bool OVERRIDE process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 return false;
 
             case KC_AP_LED_OFF:
-                annepro2LedPrevProfile();
                 annepro2LedDisable();
+                ledEnabled = false;
                 break;
 
             case KC_AP_LED_ON:
-                annepro2LedNextProfile();
-                annepro2LedEnable();
+                if (ledEnabled) {
+                    annepro2LedNextProfile();
+                } else {
+                    ledEnabled = true;
+                    annepro2LedEnable();
+                }
                 break;
 
             case KC_AP_LED_NEXT_PROFILE:


### PR DESCRIPTION
To enable LEDs we need to send the signal to enable the LED and then trigger the profile.
For triggering the profile, current logic calls `annepro2LedNextProfile()` which makes it convenient to reuse the same key for both enabling and switching to next profiles. Because of that when we enable LEDs, we always end up at the next profile instead of the one we previously used. A workaround was to switch to previous profile in the `KC_AP_LED_OFF` handler.
That made both `KC_AP_LED_OFF` and `KC_AP_LED_ON` unnecessarily complex and flicker was noticeable when using those keys. In addition, if using `KC_AP_LED_ON` instead of `KC_AP_LED_NEXT_PROFILE`, it was slower. My fix is to not make the extra calls.

This needs a small change in the shine repo which is provided [here](https://github.com/OpenAnnePro/AnnePro2-Shine/pull/24/files)