### PR TITLE
Add LED documentation

### DIFF
--- a/keyboards/annepro2/keymaps/default-full-caps/keymap.c
+++ b/keyboards/annepro2/keymaps/default-full-caps/keymap.c
@@ -8,6 +8,7 @@ enum anne_pro_layers {
   _FN2_LAYER,
 };
 
+// Key symbols are based on QMK. Use them to remap your keyboard
 /*
 * Layer _BASE_LAYER
 * ,-----------------------------------------------------------------------------------------.
@@ -95,6 +96,18 @@ void matrix_init_user(void) {
 }
 
 void matrix_scan_user(void) {
+}
+
+// Code to run after initializing the keyboard
+void keyboard_post_init_user(void) {
+    // Here are two common functions that you can use. For more LED functions, refer to the file "qmk_ap2_led.h"
+
+    // annepro2-shine disables LEDs by default. Uncomment this function to enable them at startup.
+    // annepro2LedEnable();
+
+    // Additionally, it also chooses the first LED profile by default. Refer to the "profiles" array in main.c in
+    // annepro2-shine to see the order. Replace "i" with the index of your preferred profile. (i.e the RED profile is index 0)
+    // annepro2LedSetProfile(i);
 }
 
 layer_state_t layer_state_set_user(layer_state_t layer) {

--- a/keyboards/annepro2/keymaps/default-layer-indicators/keymap.c
+++ b/keyboards/annepro2/keymaps/default-layer-indicators/keymap.c
@@ -8,6 +8,7 @@ enum anne_pro_layers {
   _FN2_LAYER,
 };
 
+// Key symbols are based on QMK. Use them to remap your keyboard
 /*
 * Layer _BASE_LAYER
 * ,-----------------------------------------------------------------------------------------.
@@ -95,6 +96,18 @@ void matrix_init_user(void) {
 }
 
 void matrix_scan_user(void) {
+}
+
+// Code to run after initializing the keyboard
+void keyboard_post_init_user(void) {
+    // Here are two common functions that you can use. For more LED functions, refer to the file "qmk_ap2_led.h"
+
+    // annepro2-shine disables LEDs by default. Uncomment this function to enable them at startup.
+    // annepro2LedEnable();
+
+    // Additionally, it also chooses the first LED profile by default. Refer to the "profiles" array in main.c in
+    // annepro2-shine to see the order. Replace "i" with the index of your preferred profile. (i.e the RED profile is index 0)
+    // annepro2LedSetProfile(i);
 }
 
 layer_state_t layer_state_set_user(layer_state_t layer) {

--- a/keyboards/annepro2/keymaps/default/keymap.c
+++ b/keyboards/annepro2/keymaps/default/keymap.c
@@ -8,6 +8,7 @@ enum anne_pro_layers {
   _FN2_LAYER,
 };
 
+// Key symbols are based on QMK. Use them to remap your keyboard
 /*
 * Layer _BASE_LAYER
 * ,-----------------------------------------------------------------------------------------.
@@ -95,6 +96,18 @@ void matrix_init_user(void) {
 }
 
 void matrix_scan_user(void) {
+}
+
+// Code to run after initializing the keyboard
+void keyboard_post_init_user(void) {
+    // Here are two common functions that you can use. For more LED functions, refer to the file "qmk_ap2_led.h"
+
+    // annepro2-shine disables LEDs by default. Uncomment this function to enable them at startup.
+    // annepro2LedEnable();
+
+    // Additionally, it also chooses the first LED profile by default. Refer to the "profiles" array in main.c in
+    // annepro2-shine to see the order. Replace "i" with the index of your preferred profile. (i.e the RED profile is index 0)
+    // annepro2LedSetProfile(i);
 }
 
 layer_state_t layer_state_set_user(layer_state_t layer) {


### PR DESCRIPTION
Added information for customizing the LEDs from keymap.c, referencing the functions that can be used, and two of the common ones that would be used.  It would be preferable to have this mentioned on the website as well.